### PR TITLE
Fix lint errors, release v.1.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,11 @@ Generally, it works on 64 bits architecture of any Linux, macOS, and Windows wit
 
 It's simple. Just update the `version` in [package.json](./package.json), then make a Pull Request. That's it!
 
-```js
+```jsonc
 {
   "name": "hasura-cli",
   "version": "1.3.0", // Patch this to "1.3.1-beta.1", for example.
-  "license": "MIT",
+  "license": "MIT"
   // ...
 }
 ```

--- a/docs/NOTE.md
+++ b/docs/NOTE.md
@@ -32,11 +32,13 @@ See `moduleNameMapper` field for corresponding configuration on jest.config.js.
 
 For example,
 
+<!-- eslint-skip -->
+
 ```js
 {
   // A map from regular expressions to module names that allow to stub out resources with a single module
-  moduleNameMapper: {
-    "^#/(.*)$": "<rootDir>/src/$1",
+  "moduleNameMapper": {
+    "^#/(.*)$": "<rootDir>/src/$1"
   }
 }
 ```
@@ -47,13 +49,15 @@ means **#/** will be matched to **src/**.
 
 `eslint-plugin-import` and `eslint-import-resolver-typescript` respect tsconfig.json by the configuration below in .eslintrc.js.
 
+<!-- eslint-skip -->
+
 ```js
 {
-  settings: {
+  "settings": {
     "import/resolver": {
-      typescript: {} // this loads <rootdir>/tsconfig.json to eslint
-    },
-  },
+      "typescript": {} // this loads <rootdir>/tsconfig.json to eslint
+    }
+  }
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hasura-cli",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "license": "MIT",
   "engines": {
     "node": ">=8"


### PR DESCRIPTION
Commit https://github.com/jjangga0214/hasura-cli/commit/fe7bb8cb670da658038b4ad86c5471c51adc3ba9 sets a few snippets to `js` for proper syntax highlighting, but since `eslint` can't parse them, they cause the [lint task to fail](https://github.com/jjangga0214/hasura-cli/pull/49/checks?check_run_id=1107435140#step:9:8). 

This PR [skips those snippets as recommended by `eslint-plugin-markdown`](https://github.com/eslint/eslint-plugin-markdown#skipping-blocks) in `docs/NOTE.md`, and switches the invalid one in `README.md` to `jsonc` (JSON with comments), which also isn't parsed by `eslint` but highlights the snippet as expected.

Second commit is a release.

Closes #48 
Closes #49