### PR TITLE
chore(release): v2.0.0-alpha.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hasura-cli",
-  "version": "2.0.0-alpha.7",
+  "version": "2.0.0-alpha.8",
   "license": "MIT",
   "engines": {
     "node": ">=8"


### PR DESCRIPTION
New v2 alpha prerelease: https://github.com/hasura/graphql-engine/releases/tag/v2.0.0-alpha.8