### PR TITLE
Update version to 2.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hasura-cli",
-  "version": "2.3.0-beta.1",
+  "version": "2.3.1",
   "license": "MIT",
   "engines": {
     "node": ">=8"


### PR DESCRIPTION
Latest stable version on npm is 2.2.0, but actual latest Hasura CLI version is [2.3.1](https://github.com/hasura/graphql-engine/releases/tag/v2.3.1).

This PR updates the version in package.json, as stated in the README.