### PR TITLE
chore(release): v2.15.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hasura-cli",
-  "version": "2.15.1",
+  "version": "2.15.2",
   "license": "MIT",
   "engines": {
     "node": ">=8"


### PR DESCRIPTION
Updates to a version not affected by a recently disclosed [critical security vulnerability](https://hasura.io/blog/critical-vulnerability-in-hasuras-graphql-engine-v2-10-0/). 