### PR TITLE
chore(release): v2.26.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hasura-cli",
-  "version": "2.25.0",
+  "version": "2.26.0",
   "license": "MIT",
   "engines": {
     "node": ">=8"


### PR DESCRIPTION
ref: 
https://github.com/hasura/graphql-engine/releases/tag/v2.26.0