### PR TITLE
fix: missing dist on npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint:md": "markdownlint --fix",
     "lint:all": "pnpm lint . && pnpm lint:md .",
     "test": "cross-env NODE_OPTIONS=--experimental-vm-modules NODE_NO_WARNINGS=1 jest",
-    "build": "shx rm -rf dist/* && tsc -p tsconfig.build.json",
+    "build": "shx rm -rf dist/* tsconfig.build.tsbuildinfo && tsc -p tsconfig.build.json",
     "build:watch": "tsc -p tsconfig.build.json -w",
     "prepublishOnly": "pnpm build",
     "dev:build": "concurrently 'tsc -w -i' 'nodemon dist/index.js'",


### PR DESCRIPTION
Fix https://github.com/jjangga0214/hasura-cli/issues/116

Currently, [incremental compilation](https://www.typescriptlang.org/tsconfig/#incremental) is enabled on our project. While it can speeds up builds by reusing information from previous compilations, it may leads to build issues. Like in our case, after we execute `shx rm -rf dist/*` , `tsc -p tsconfig.build.json` does not result anything since it does not detect any TS file changes. 

One solution is to remove generated `tsbuildinfo` like what this PR does. If this is not a good solution, this second solution might be the choice:  Disabling `composite` and `incremental` option

Any feedbacks are welcome @jjangga0214 